### PR TITLE
Set the maintenance window to 2:00-6:00 UTC

### DIFF
--- a/templates/custom.config.php.epp
+++ b/templates/custom.config.php.epp
@@ -63,4 +63,7 @@ $CONFIG = array (
 
   // silent annoying messages
   'encryption.legacy_format_support' => false,
+
+  // maintenance schedule
+  'maintenance_window_start' => 2, // From 2 AM. to 6 AM. UTC
 );


### PR DESCRIPTION
This silent a warning in administration tab related to intensive task runned by cron

See https://docs.nextcloud.com/server/28/admin_manual/configuration_server/background_jobs_configuration.html