### PR TITLE
Ignore output from cron execution

### DIFF
--- a/manifests/base.pp
+++ b/manifests/base.pp
@@ -27,7 +27,7 @@ class nextcloud::base {
   }
 
   cron { 'nextcloud-cron':
-    command => "/usr/bin/php -f ${nextcloud::current_version_dir}/cron.php",
+    command => "/usr/bin/php -f ${nextcloud::current_version_dir}/cron.php > /dev/null 2>&1",
     user    => $nextcloud::user,
     minute  => '*/15',
   }


### PR DESCRIPTION
Some processing in the cron task occasionaly produce output that result
in an e-mail being sent.

On our fleet, it happens less than 1 time a day, and only contain 1 or
more of the following line:

```
libpng warning: iCCP: known incorrect sRGB profile
```

These warning are not actionable, so we can probably just ignore them.
